### PR TITLE
Update MainMenu_Inventory.cs

### DIFF
--- a/Player/Main Menu/MainMenu_Inventory.cs
+++ b/Player/Main Menu/MainMenu_Inventory.cs
@@ -591,6 +591,9 @@ namespace ChampionsOfForest
 									}
 								}
 							}
+							
+							// Prevent Inventory Item Dupe
+                            if (CustomCrafting.isIngredient(index)) canPlace = false;
 
 							if (canPlace || index > -1)
 							{


### PR DESCRIPTION
Just a little code to prevent players from duplicating items. Glitch works when you replace an ingredient item with any item from your inventory, so in result, people were managing to glitch low level items as substance for high level.